### PR TITLE
chore: use scope all to fetch markets and enable interactions

### DIFF
--- a/recipes/borrow.ts
+++ b/recipes/borrow.ts
@@ -279,12 +279,17 @@ class BorrowApiClient {
     network?: string;
     limit?: number;
     offset?: number;
+    scope?: "enabled" | "all";
   }): Promise<PaginatedResponse<MarketDto>> {
     const query = new URLSearchParams();
     if (params?.integrationId) query.append("integrationId", params.integrationId);
     if (params?.network) query.append("network", params.network);
     if (params?.limit !== undefined) query.append("limit", params.limit.toString());
     if (params?.offset !== undefined) query.append("offset", params.offset.toString());
+    // The markets endpoint defaults to scope=enabled, which hides markets that
+    // aren't enabled for your project. The recipe is a dev tool, so we opt into
+    // the full list by default; action creation will still enforce enablement.
+    query.append("scope", params?.scope ?? "all");
 
     const queryString = query.toString();
     return this.makeRequest<PaginatedResponse<MarketDto>>(


### PR DESCRIPTION
## Added

Optional scope: "enabled" | "all" parameter on BorrowApiClient.getMarkets in the borrow recipe, mirroring the new scope query param on GET /v1/markets.

## Changed

The borrow recipe now defaults scope to "all" when listing markets (Browse Markets, Supply/Borrow/Repay/Withdraw flows), so users see every market the integration exposes instead of only those enabled on their project. Per-market enablement is still enforced server-side at action creation time.
